### PR TITLE
Relax media parsing, fix data url parsing

### DIFF
--- a/js/css_parser/css_parse.js
+++ b/js/css_parser/css_parse.js
@@ -64,7 +64,7 @@ function css_parse(css, silent)
 		
 		if(!match(/^:\s*/)) return error("property missing ':'");
 		
-		var val = match(/^((?:\/\*.*?\*\/|'(?:\\'|.)*?'|"(?:\\"|.)*?"|\([^\)]*?\)|[^};])+)/);
+		var val = match(/^((?:\/\*.*?\*\/|'(?:\\'|.)*?'|"(?:\\"|.)*?"|\([^\)]*?['"]\)|[^};])+)/);
 		
 		var ret = { type: 'declaration', property: prop.replace(comment_regexp, ''), value: val ? val[0].replace(comment_regexp, '').trim() : '' };
 		
@@ -129,7 +129,7 @@ function css_parse(css, silent)
 
 	function rule()
 	{
-		var sel = selector(); if(!sel) return error('selector missing');
+		var sel = selector() || []; if(!sel.length) error('selector missing');
 		
 		return { type: 'rule', selectors: sel, declarations: declarations() };
 	}//___________________________________________________________________________


### PR DESCRIPTION
This is a great package. I'm using it to parse CSS in the wild to extract data. A lot of it is invalid, so it is nice to have a parser that is as liberal as the browser one.
This PR fixes the regex similar to https://github.com/reworkcss/css/pull/110 and adds recovery after a rule with no selector. 

``` CSS
@media screen and (max-width: 767px) { {
    width: 100%;
}
}
#id {
    position: fixed;
}
```