### PR TITLE
Handle urls without quotes and with semicolon

### DIFF
--- a/js/css_parser/css_parse.js
+++ b/js/css_parser/css_parse.js
@@ -63,8 +63,9 @@ function css_parse(css, silent)
 		prop = prop[0].trim();
 		
 		if(!match(/^:\s*/)) return error("property missing ':'");
-		
-		var val = match(/^((?:\/\*.*?\*\/|'(?:\\'|.)*?'|"(?:\\"|.)*?"|\([^\)]*?['"]\)|[^};])+)/);
+
+		// Quotes regex repeats verbatim inside and outside parentheses
+		var val = match(/^((?:\/\*.*?\*\/|'(?:\\'|.)*?'|"(?:\\"|.)*?"|\((\s*'(?:\\'|.)*?'|"(?:\\"|.)*?"|[^)]*?)\s*\)|[^};])+)/);
 		
 		var ret = { type: 'declaration', property: prop.replace(comment_regexp, ''), value: val ? val[0].replace(comment_regexp, '').trim() : '' };
 		


### PR DESCRIPTION
In the previous PR I broke the case when urls don't have quotes and have weird symbols inside. The fix is to try to parse values with quotes first, then without.

This is a testcase for the fix

``` css
#Categories li, .bullet-list li, .location-depth-3 li {
    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAEBAMAAABb34NNAAAAFVBMVEXyrmHqcBDtdQ3pcRHcbRkAAAD/uSmYi/+cAAAABnRSTlORbFE2DwAwkbURAAAAEUlEQVQI12MIEmEwSwAiIAMAC/AB+fq6WIgAAAAASUVORK5CYII=);
    background-repeat: no-repeat
}
```